### PR TITLE
Fix connection closing logic in ssh.py

### DIFF
--- a/ananta/ssh.py
+++ b/ananta/ssh.py
@@ -129,7 +129,8 @@ async def execute_command(
     except asyncssh.Error as error:
         output = f"Error executing command: {error}"
     finally:
-        await conn.close()  # type: ignore[func-returns-value]
+        if conn:
+            conn.close()
     return output
 
 


### PR DESCRIPTION
# Case
```shell
ananta -s hosts.toml cat /etc/os-release
  File "python3.13/site-packages/ananta/ssh.py", line 132, in execute_command
    await conn.close()  # type: ignore[func-returns-value]
    ^^^^^^^^^^^^^^^^^^
TypeError: object NoneType can't be used in 'await' expression
```

# Describe
fix ananta crashed when output seperately